### PR TITLE
feat: implement dynamic dashboard API endpoint

### DIFF
--- a/roommate-server/DASHBOARD_API.md
+++ b/roommate-server/DASHBOARD_API.md
@@ -1,0 +1,192 @@
+# Dashboard API Documentation
+
+## Overview
+
+The Dashboard API provides dynamic statistics for the user's dashboard, including household count, pending chores, and monthly expenses.
+
+## Endpoint
+
+### GET `/dashboard`
+
+Returns aggregated statistics for the authenticated user's dashboard.
+
+#### Authentication
+
+Required: Yes (JWT Bearer Token)
+
+#### Request Headers
+
+```
+Authorization: Bearer <access_token>
+```
+
+#### Response
+
+**Success Response (200 OK)**
+
+```json
+{
+  "message": "Dashboard stats retrieved successfully",
+  "data": {
+    "households": {
+      "label": "Active Households",
+      "value": 2
+    },
+    "chores": {
+      "label": "Pending Tasks",
+      "value": 5
+    },
+    "expenses": {
+      "label": "This Month",
+      "value": 1234.56
+    }
+  }
+}
+```
+
+**Error Response (401 Unauthorized)**
+
+```json
+{
+  "message": "Unauthorized"
+}
+```
+
+**Error Response (500 Internal Server Error)**
+
+```json
+{
+  "message": "Unable to fetch dashboard stats"
+}
+```
+
+## Data Fields
+
+### households
+- **label**: "Active Households"
+- **value**: Number of households the user is a member of
+
+### chores
+- **label**: "Pending Tasks"
+- **value**: Number of incomplete chores assigned to the user
+
+### expenses
+- **label**: "This Month"
+- **value**: Total amount of expenses in the current month across all user's households (rounded to 2 decimal places)
+
+## Usage Examples
+
+### cURL
+
+```bash
+curl -X GET http://localhost:5000/dashboard \
+  -H "Authorization: Bearer YOUR_ACCESS_TOKEN"
+```
+
+### JavaScript (Axios)
+
+```javascript
+import axios from 'axios';
+
+const getDashboardStats = async () => {
+  try {
+    const response = await axios.get('http://localhost:5000/dashboard', {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching dashboard stats:', error);
+    throw error;
+  }
+};
+```
+
+### Frontend Integration (React)
+
+```typescript
+import { useEffect, useState } from 'react';
+import api from '@/api/axios';
+
+interface DashboardStats {
+  households: { label: string; value: number };
+  chores: { label: string; value: number };
+  expenses: { label: string; value: number };
+}
+
+const Dashboard = () => {
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchStats = async () => {
+      try {
+        const response = await api.get('/dashboard');
+        setStats(response.data);
+      } catch (error) {
+        console.error('Failed to fetch dashboard stats:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <div>Active Households: {stats?.households.value}</div>
+      <div>Pending Tasks: {stats?.chores.value}</div>
+      <div>This Month: ${stats?.expenses.value}</div>
+    </div>
+  );
+};
+```
+
+## Implementation Details
+
+### Database Queries
+
+1. **Household Count**: Counts records in `HouseholdMember` table for the user
+2. **Pending Chores**: Counts records in `Chore` table where `assignedToId` matches user and `completed` is false
+3. **Monthly Expenses**: Aggregates sum of `amount` from `Expense` table for current month in user's households
+
+### Performance
+
+All three queries are executed in parallel using `Promise.all()` for optimal performance.
+
+### Date Range
+
+The monthly expenses calculation uses the current month's start and end dates (inclusive) based on the server's timezone.
+
+## Testing
+
+To test the endpoint, ensure:
+
+1. Server is running on port 5000
+2. User is authenticated with a valid JWT token
+3. User has at least one household membership
+
+Example test flow:
+
+```bash
+# 1. Register/Login to get access token
+curl -X POST http://localhost:5000/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"user@example.com","password":"password123"}'
+
+# 2. Use the returned access token to call dashboard endpoint
+curl -X GET http://localhost:5000/dashboard \
+  -H "Authorization: Bearer <access_token_from_step_1>"
+```
+
+## Notes
+
+- All monetary values are rounded to 2 decimal places
+- The endpoint requires a valid authentication token
+- Statistics are user-specific and isolated by household membership
+- Expense calculations only include expenses from the current calendar month

--- a/roommate-server/src/dashboard/dashboard.controller.ts
+++ b/roommate-server/src/dashboard/dashboard.controller.ts
@@ -1,0 +1,18 @@
+import { Request, Response } from "express";
+import { DashboardService } from "@src/dashboard/dashboard.service";
+import { getUserFromRequestBody } from "@src/common/utils/utils";
+
+export class DashboardController {
+  static async getStats(request: Request, response: Response) {
+    const { userId } = getUserFromRequestBody(request);
+
+    const { status, data, message } = await DashboardService.getDashboardStats(
+      userId
+    );
+
+    return response.status(status).json({
+      message: message,
+      data: data,
+    });
+  }
+}

--- a/roommate-server/src/dashboard/dashboard.repo.ts
+++ b/roommate-server/src/dashboard/dashboard.repo.ts
@@ -1,0 +1,59 @@
+import prisma from "@common/utils/prisma";
+import { startOfMonth, endOfMonth } from "date-fns";
+
+export class DashboardRepo {
+  static async getHouseholdCount(userId: string): Promise<number> {
+    const count = await prisma.householdMember.count({
+      where: {
+        userId: userId,
+      },
+    });
+
+    return count;
+  }
+
+  static async getPendingChoresCount(userId: string): Promise<number> {
+    const count = await prisma.chore.count({
+      where: {
+        assignedToId: userId,
+        completed: false,
+      },
+    });
+
+    return count;
+  }
+
+  static async getCurrentMonthExpenses(userId: string): Promise<number> {
+    const now = new Date();
+    const monthStart = startOfMonth(now);
+    const monthEnd = endOfMonth(now);
+
+    const userHouseholds = await prisma.householdMember.findMany({
+      where: {
+        userId: userId,
+      },
+      select: {
+        householdId: true,
+      },
+    });
+
+    const householdIds = userHouseholds.map((hm) => hm.householdId);
+
+    const result = await prisma.expense.aggregate({
+      where: {
+        householdId: {
+          in: householdIds,
+        },
+        createdAt: {
+          gte: monthStart,
+          lte: monthEnd,
+        },
+      },
+      _sum: {
+        amount: true,
+      },
+    });
+
+    return result._sum.amount || 0;
+  }
+}

--- a/roommate-server/src/dashboard/dashboard.routes.ts
+++ b/roommate-server/src/dashboard/dashboard.routes.ts
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { DashboardController } from "@src/dashboard/dashboard.controller";
+import ensureAuthenticated from "@src/auth/middlewares/ensureAuthenticated";
+
+const dashboardRouter = Router();
+
+dashboardRouter.get("/", ensureAuthenticated, DashboardController.getStats);
+
+export default dashboardRouter;

--- a/roommate-server/src/dashboard/dashboard.service.ts
+++ b/roommate-server/src/dashboard/dashboard.service.ts
@@ -1,0 +1,44 @@
+import { StatusCodes } from "http-status-codes";
+import { ApiResponse } from "@src/common/utils/ApiResponse";
+import { DashboardRepo } from "@src/dashboard/dashboard.repo";
+import { DashboardStatsType } from "@src/dashboard/types/DashboardStatsType";
+
+export class DashboardService {
+  static async getDashboardStats(userId: string) {
+    try {
+      const [householdCount, pendingChoresCount, monthlyExpenses] =
+        await Promise.all([
+          DashboardRepo.getHouseholdCount(userId),
+          DashboardRepo.getPendingChoresCount(userId),
+          DashboardRepo.getCurrentMonthExpenses(userId),
+        ]);
+
+      const dashboardStats: DashboardStatsType = {
+        households: {
+          label: "Active Households",
+          value: householdCount,
+        },
+        chores: {
+          label: "Pending Tasks",
+          value: pendingChoresCount,
+        },
+        expenses: {
+          label: "This Month",
+          value: Math.round(monthlyExpenses * 100) / 100,
+        },
+      };
+
+      return ApiResponse.success(
+        dashboardStats,
+        "Dashboard stats retrieved successfully",
+        StatusCodes.OK
+      );
+    } catch (error) {
+      console.error("Error fetching dashboard stats:", error);
+      return ApiResponse.error(
+        "Unable to fetch dashboard stats",
+        StatusCodes.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+}

--- a/roommate-server/src/dashboard/types/DashboardStatsType.ts
+++ b/roommate-server/src/dashboard/types/DashboardStatsType.ts
@@ -1,0 +1,14 @@
+export interface DashboardStatsType {
+  households: {
+    label: string;
+    value: number;
+  };
+  chores: {
+    label: string;
+    value: number;
+  };
+  expenses: {
+    label: string;
+    value: number;
+  };
+}

--- a/roommate-server/src/routes.ts
+++ b/roommate-server/src/routes.ts
@@ -6,6 +6,7 @@ import expenseRouter from "@src/expenses/expense.routes";
 import choreRouter from "@src/chore/chore.routes";
 import inventoryRouter from "@src/inventory/inventory.routes";
 import hosueholdMemberRouter from "@src/household-members/householdMember.routes";
+import dashboardRouter from "@src/dashboard/dashboard.routes";
 
 //NOTE - common syntex for routes
 // routes.use('/path', middleware, specificActionsOnThePath);
@@ -31,5 +32,7 @@ routes.use("/expense", expenseRouter);
 routes.use("/chore", choreRouter);
 
 routes.use("/inventory", inventoryRouter);
+
+routes.use("/dashboard", dashboardRouter);
 
 export default routes;


### PR DESCRIPTION
- Add GET /dashboard endpoint with JWT authentication
- Implement three dynamic statistics:
  * Active households count
  * Pending chores count
  * Current month expenses total
- Create dashboard module with repo, service, controller layers
- Add parallel query execution for optimal performance
- Include comprehensive API documentation

Closes #44