### PR TITLE
fix: handle FK constraint by deleting expenseSplits before expense

### DIFF
--- a/roommate-app/src/pages/expenses/Expenses.tsx
+++ b/roommate-app/src/pages/expenses/Expenses.tsx
@@ -29,24 +29,23 @@ function Expenses() {
     useState<MemberOptions>([{ key: "", value: "" }]);
 
   const getExpenses = async () => {
+    if (!selectedHousehold?.key) {
+      setExpenses([]);
+      return;
+    }
     const expensesByHousehold = await ExpenseApi.fetchByHouseholdId(
       selectedHousehold?.key
     );
-
-    if (expensesByHousehold && expensesByHousehold.length > 0)
-      setExpenses([...expensesByHousehold]);
+    setExpenses(expensesByHousehold || []);
   };
 
   const handleDeleteExpense = async (expenseId: string) => {
     try {
       const deletedExpense = await ExpenseApi.deleteByExpenseId(expenseId);
       if (deletedExpense) {
-        const expenseList = expenses?.filter(
-          (expense) => expense.expenseId !== expenseId
+        setExpenses((prevExpenses) =>
+          prevExpenses.filter((expense) => expense.expenseId !== expenseId)
         );
-
-        setExpenses(expenseList);
-        getExpenses();
       }
     } catch (error) {
       console.error(error);

--- a/roommate-server/src/expenses/expense.repo.ts
+++ b/roommate-server/src/expenses/expense.repo.ts
@@ -38,8 +38,14 @@ export class ExpenseRepo {
   }
 
   static async delete(expenseId: string) {
-    return await prisma.expense.delete({
-      where: { expenseId: expenseId },
+    return await prisma.$transaction(async (tx) => {
+      await tx.expenseSplit.deleteMany({
+        where: { expenseId: expenseId },
+      });
+
+      return await tx.expense.delete({
+        where: { expenseId: expenseId },
+      });
     });
   }
 


### PR DESCRIPTION
# Changes
Fixes #50 

### Backend:
- Updated the delete logic to use a transaction.
- Now we first delete related expenseSplit entries before deleting the main expense.
- This avoids the foreign key constraint errors we were running into when trying to delete expenses that still had associated splits.
- Without this, deleting would fail silently or throw DB errors.

### Frontend:
- Improved the getExpenses function
- cleaned up handleDeleteExpense function.

Now you can see real time changes after deletion 

# Recording:

https://github.com/user-attachments/assets/d14f30cc-82dd-4b21-8502-54c161b7817c

