### PR TITLE
Fix/infinite household api calls

### DIFF
--- a/roommate-app/src/pages/households/Households.tsx
+++ b/roommate-app/src/pages/households/Households.tsx
@@ -17,7 +17,7 @@ function Households() {
     }, 10000);
     
     return () => clearInterval(interval);
-  }, [fetchAllHouseholds]);
+  }, []);
 
   const sortedHouseholds = [...households].sort((a, b) => 
     new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()


### PR DESCRIPTION
## Related Issue
Closes #56 

---

## Changes Introduced
- Removed `fetchAllHouseholds` from `useEffect` dependency array

---

## Why This Change?
Previously, `fetchAllHouseholds` was listed in the dependency array of `useEffect`.  
Since function references can change on re-render, React kept re-running the effect infinitely, leading to repeated API calls.

This fix ensures:
- The household data is fetched once when the component mounts
- Refreshed every 10 seconds
- No infinite loop occurs

---

## Testing
- [x] Verified only one initial fetch occurs
- [x] Confirmed refresh works every 10 seconds
- [x] Checked cleanup on component unmount
- [x] No redundant API calls

---

## 💬 Additional Notes
This fix keeps the auto-refresh logic intact while preventing React’s dependency re-invocation issue.
