### PR TITLE
fix: fixed expense api and status code

### DIFF
--- a/roommate-app/src/api/expenseApi.ts
+++ b/roommate-app/src/api/expenseApi.ts
@@ -3,8 +3,8 @@ import type { CreateExpenseRequestType } from "@/types/expenseTypes";
 
 const expenseApi = () => {
   const create = async (requestBody: CreateExpenseRequestType) => {
-    const { data } = await api.post("/expense/add", requestBody);
-    return data;
+    const { data, status } = await api.post("/expense/add", requestBody);
+    return { data, status };
   };
 
   const fetchByHouseholdId = async (householdId: string | undefined) => {

--- a/roommate-app/src/components/expenses/AddExpenseForm.tsx
+++ b/roommate-app/src/components/expenses/AddExpenseForm.tsx
@@ -77,7 +77,7 @@ export default function AddExpenseForm({
         getExpenses();
         return response;
       });
-      if (resp && resp.status == 200) {
+      if (resp && resp.status == 201) {
         toast.success("Expense added successfully!", {
           position: "top-center",
         });

--- a/roommate-server/src/expenses/expense.controller.ts
+++ b/roommate-server/src/expenses/expense.controller.ts
@@ -62,6 +62,7 @@ export class ExpenseController {
     return response.status(status).json({
       message: message,
       data: data,
+      status,
     });
   }
 }


### PR DESCRIPTION
Closes: #57 
# Updated Expense creation for status response:
- Adjusted the API response handling to return both `data` and `status`. 
- Updated the right status code in `AddExpenseForm.tsx` from `200` to `201`.
- Updated the backend controller to ensure it sends both the status  and data in the response.


# ScreenShot:
<img width="1647" height="1080" alt="image" src="https://github.com/user-attachments/assets/c6b98887-7dcd-4f21-8dff-4769f803d970" />
